### PR TITLE
Error when using with no arguments or options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import ScrollBehavior from 'scroll-behavior'
 import SessionStorage from './SessionStorage'
 
-export default ({ shouldUpdateScroll, manual }) => history => {
+export default ({ shouldUpdateScroll, manual } = {}) => history => {
   const stateStorage = new SessionStorage()
 
   const behavior = new ScrollBehavior({


### PR DESCRIPTION
When calling `restoreScroll` with no arguments, there was an error because it was trying to destructure undefined.