### PR TITLE
Fix session storage access denied error when cookies disabled

### DIFF
--- a/src/SessionStorage.js
+++ b/src/SessionStorage.js
@@ -9,8 +9,13 @@ export default class SessionStorage {
 
   read(location, key) {
     const stateKey = this.getStateKey(location, key)
-    const value = sessionStorage.getItem(stateKey)
-    return JSON.parse(value)
+    try {
+      const value = sessionStorage.getItem(stateKey)
+      return JSON.parse(value)
+    }
+    catch (e) {
+      console.warn(e)
+    }
   }
 
   save(location, key, value) {
@@ -20,7 +25,13 @@ export default class SessionStorage {
 
     const stateKey = this.getStateKey(location, key)
     const storedValue = JSON.stringify(value)
-    sessionStorage.setItem(stateKey, storedValue)
+
+    try {
+      sessionStorage.setItem(stateKey, storedValue)
+    }
+    catch (e) {
+      console.warn(e)
+    }
 
     if (key) {
       const newKey = location.key || location.hash || 'loadPage'


### PR DESCRIPTION
If a user has their cookies blocked and the script is unable to access their session storage, this changes the console error to a console warning. 

Before:
![image](https://user-images.githubusercontent.com/13035971/47117774-5077e580-d233-11e8-9ff0-2a5410a1385f.png)

After:
![screen shot 2018-10-17 at 5 40 24 pm](https://user-images.githubusercontent.com/13035971/47117963-dd22a380-d233-11e8-89e9-ffb0064dcb17.png)

